### PR TITLE
add doctype and lang attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>The News</title>
   </head>

--- a/index.html
+++ b/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <title>The News</title>


### PR DESCRIPTION
For historical reasons, browsers behave more predictably and more uniformly when they parse HTML documents that start with a so-called Doctype declaration:

`<!DOCTYPE html>`

reference: https://www.w3.org/QA/Tips/Doctype